### PR TITLE
implement redeem function in sellable contract

### DIFF
--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -27,7 +27,7 @@ pub struct Metadata {
 
 pub type Extension = Option<Metadata>;
 
-pub type Cw721MetadataContract<'a> = cw721_base::Cw721Contract<'a, Extension, Empty>;
+pub type Cw721MetadataContract<'a> = cw721_base::Cw721Contract<'a, Extension, Empty, Empty>;
 pub type ExecuteMsg = cw721_base::ExecuteMsg<Extension>;
 
 #[cfg(not(feature = "library"))]

--- a/contracts/cw721-sellable/src/error.rs
+++ b/contracts/cw721-sellable/src/error.rs
@@ -9,6 +9,12 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    #[error("Redeemed")]
+    Redeemed,
+
+    #[error("Locked")]
+    Locked,
+
     #[error("No tokens listed for sale")]
     NoListedTokensError,
 

--- a/contracts/cw721-sellable/src/error.rs
+++ b/contracts/cw721-sellable/src/error.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     #[error("Locked")]
     Locked,
 
+    #[error("NoMetadataPresent")]
+    NoMetadataPresent,
+
     #[error("No tokens listed for sale")]
     NoListedTokensError,
 

--- a/contracts/cw721-sellable/src/execute.rs
+++ b/contracts/cw721-sellable/src/execute.rs
@@ -103,7 +103,6 @@ pub fn try_list(
 
 pub fn try_redeem(
     deps: DepsMut,
-    env: Env,
     info: MessageInfo,
     address: String,
     ticket_id: &String

--- a/contracts/cw721-sellable/src/execute.rs
+++ b/contracts/cw721-sellable/src/execute.rs
@@ -101,6 +101,53 @@ pub fn try_list(
     Ok(Response::new().add_attribute("method", "list"))
 }
 
+pub fn try_redeem(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    address: String,
+    ticket_id: &String
+) -> Result<Response, ContractError> {
+    let contract = Cw721SellableContract::default();
+
+    // Validate only contract owner can call method
+    let minter = contract.minter.load(deps.storage)?;
+    if info.sender != minter {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // Load ticket, error if ticket does not exist
+    let mut ticket = contract.tokens.load(deps.storage, ticket_id)?;
+
+    // Make sure owner param matches ticket owner
+    if ticket.owner != address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    // Make sure ticket isn't locked or redeemed
+    match ticket.extension {
+        Some(ref metadata) => if (*metadata).redeemed.unwrap_or(false) {
+            return Err(ContractError::Redeemed);
+        } else if (*metadata).locked.unwrap_or(false) {
+            return Err(ContractError::Locked);
+        },
+        None => ()
+    }
+
+    // Mark ticket as redeemed and locked
+    match ticket.extension {
+        Some(ref mut metadata) => {
+            (*metadata).redeemed = Some(true);
+            (*metadata).locked = Some(true);
+        },
+        None => ()
+    }
+    // Save change into storage
+    contract.tokens.save(deps.storage, ticket_id, &ticket)?;
+
+    return Ok(Response::new().add_attribute("method", "redeem"))
+}
+
 // todo: is there a way to use the cw721 base function here?
 pub fn check_can_send(
     deps: Deps,

--- a/contracts/cw721-sellable/src/execute.rs
+++ b/contracts/cw721-sellable/src/execute.rs
@@ -6,7 +6,6 @@ use cosmwasm_std::{
 };
 use schemars::Map;
 
-
 pub fn try_buy(deps: DepsMut, info: MessageInfo, limit: Uint64) -> Result<Response, ContractError> {
     let coin = deps.querier.query_balance(&info.sender, "burnt")?;
     if coin.amount < limit.into() {
@@ -105,7 +104,7 @@ pub fn try_redeem(
     deps: DepsMut,
     info: MessageInfo,
     address: String,
-    ticket_id: &String
+    ticket_id: &String,
 ) -> Result<Response, ContractError> {
     let contract = Cw721SellableContract::default();
 
@@ -125,12 +124,14 @@ pub fn try_redeem(
 
     // Make sure ticket isn't locked or redeemed
     match ticket.extension {
-        Some(ref metadata) => if (*metadata).redeemed.unwrap_or(false) {
-            return Err(ContractError::Redeemed);
-        } else if (*metadata).locked.unwrap_or(false) {
-            return Err(ContractError::Locked);
-        },
-        None => ()
+        Some(ref metadata) => {
+            if (*metadata).redeemed.unwrap_or(false) {
+                return Err(ContractError::Redeemed);
+            } else if (*metadata).locked.unwrap_or(false) {
+                return Err(ContractError::Locked);
+            }
+        }
+        None => (),
     }
 
     // Mark ticket as redeemed and locked
@@ -138,13 +139,13 @@ pub fn try_redeem(
         Some(ref mut metadata) => {
             (*metadata).redeemed = Some(true);
             (*metadata).locked = Some(true);
-        },
-        None => ()
+        }
+        None => (),
     }
     // Save change into storage
     contract.tokens.save(deps.storage, ticket_id, &ticket)?;
 
-    return Ok(Response::new().add_attribute("method", "redeem"))
+    return Ok(Response::new().add_attribute("method", "redeem"));
 }
 
 // todo: is there a way to use the cw721 base function here?

--- a/contracts/cw721-sellable/src/lib.rs
+++ b/contracts/cw721-sellable/src/lib.rs
@@ -33,6 +33,8 @@ pub struct Metadata {
     /// question: how do we validate this?
     pub royalty_payment_address: Option<String>,
     pub list_price: Option<Uint64>,
+    pub locked: Option<bool>,
+    pub redeemed: Option<bool>
 }
 
 pub type Extension = Option<Metadata>;
@@ -48,7 +50,7 @@ mod entry {
     use super::*;
 
     use crate::error::ContractError;
-    use crate::execute::{try_buy, try_list};
+    use crate::execute::{try_buy, try_list, try_redeem};
     use crate::msg::{Cw721SellableExecuteMsg, Cw721SellableQueryMsg};
     use crate::query::listed_tokens;
     use cosmwasm_std::{entry_point, to_binary};
@@ -89,6 +91,7 @@ mod entry {
         match msg {
             List { listings } => try_list(deps, env, info, listings),
             Buy { limit } => try_buy(deps, info, limit),
+            RedeemTicket { address, ticket_id } => try_redeem(deps, env, info, address, &ticket_id),
             BaseMsg(base_msg) => Cw721SellableContract::default()
                 .execute(deps, env, info, base_msg)
                 .map_err(|x| x.into()),
@@ -99,13 +102,19 @@ mod entry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{Context, ContractInfo};
+    use crate::test_utils::test_utils::{Context, ContractInfo};
     use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg};
-
+    use crate::entry::{execute, instantiate, query};
+    use crate::error::ContractError;
+    
     use crate::msg::Cw721SellableQueryMsg;
     use crate::query::ListedTokensResponse;
-    use cosmwasm_std::testing::mock_info;
+    use cosmwasm_std::testing::{mock_info, mock_dependencies, mock_env};
     use schemars::Map;
+    use cw2981_royalties::InstantiateMsg;
+    use cw2981_royalties::msg::{Cw2981QueryMsg};
+    use cw721::{NftInfoResponse};
+    use cw721::Cw721Query;
 
     const CREATOR: &str = "creator";
     const OWNER: &str = "owner";
@@ -347,5 +356,127 @@ mod tests {
             .expect("expected token to exist");
 
         assert_eq!(enterprise_info.owner, Addr::unchecked(BUYER));
+    }
+    #[test]
+    fn redeem_ticket() {
+        let mut context = Context::new(
+            ContractInfo {
+                name: "Ticketing".to_string(),
+                symbol: "TICK".to_string(),
+            }, 
+            CREATOR,
+            Some(&[])
+        );
+
+        // Make sure only the owner of the contract can call method
+        let msg = Cw721SellableExecuteMsg::RedeemTicket {
+            address: String::from(OWNER),
+            ticket_id: String::from("OWNER_TICKET")
+        };
+        let exec_res = context.execute(mock_info(OWNER, &[]), msg).err();
+        match exec_res {
+            Some(ContractError::Unauthorized) => assert!(true),
+            _ => assert!(false),
+        };
+
+        // Throw Error if ticket does exists in the contract
+        let msg = Cw721SellableExecuteMsg::RedeemTicket {
+            address: String::from(OWNER),
+            ticket_id: String::from("OWNER_TICKET")
+        };
+        let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
+        match exec_res {
+            None => assert!(false),
+            _ => assert!(true)
+        };
+
+        // Make sure the owner param is the same as ticket owner in contract
+        let token_id = "Burnt_Event#1";
+        let mint_msg = cw721_base::MintMsg {
+            token_id: token_id.to_string(),
+            owner: OWNER.to_string(), // Create a ticket belonging to OWNER
+            token_uri: Some("https://starships.example.com/Starship/Enterprise.json".into()),
+            extension: Some(Metadata {
+                description: Some("Burnt event ticket #1".into()),
+                name: Some("Ticket #1".to_string()),
+                ..Metadata::default()
+            }),
+        };
+        let exec_msg = ExecuteMsg::BaseMsg(cw721_base::ExecuteMsg::Mint(mint_msg.clone()));
+        context.execute(mock_info(CREATOR, &[]), exec_msg).unwrap();
+
+        let msg = Cw721SellableExecuteMsg::RedeemTicket {
+            address: String::from(BUYER), // Ticket owner is BUYER here
+            ticket_id: String::from("Burnt_Event#1")
+        };
+        let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
+        match exec_res {
+            Some(ContractError::Unauthorized) => assert!(true),
+            _ => assert!(false)
+        };
+
+        // Make sure the ticket is not locked  or redeemed
+        let locked_token_id = "Burnt_Locked#1";
+        let mint_msg = cw721_base::MintMsg {
+            token_id: locked_token_id.to_string(),
+            owner: OWNER.to_string(),
+            token_uri: Some("https://starships.example.com/Starship/Enterprise.json".into()),
+            extension: Some(Metadata {
+                description: Some("Burnt locked event ticket #1".into()),
+                name: Some("Locked ticket #1".to_string()),
+                locked: Some(true),
+                ..Metadata::default()
+            }),
+        };
+        let exec_msg = ExecuteMsg::BaseMsg(cw721_base::ExecuteMsg::Mint(mint_msg.clone()));
+        context.execute(mock_info(CREATOR, &[]), exec_msg).unwrap();
+        // Try to redeem locked ticket
+        let msg = Cw721SellableExecuteMsg::RedeemTicket {
+            address: String::from(OWNER),
+            ticket_id: String::from("Burnt_Locked#1")
+        };
+        let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
+        match exec_res {
+            Some(ContractError::Locked) => assert!(true),
+            _ => assert!(false)
+        };
+
+        // Make sure the ticket metadata is updated
+        let token_id = "Burnt_Event#2";
+        let mint_msg = cw721_base::MintMsg {
+            token_id: token_id.to_string(),
+            owner: OWNER.to_string(), // Create a ticket belonging to OWNER
+            token_uri: Some("https://starships.example.com/Starship/Enterprise.json".into()),
+            extension: Some(Metadata {
+                description: Some("Burnt event ticket #1".into()),
+                name: Some("Ticket #2".to_string()),
+                locked: Some(false),
+                redeemed: Some(false),
+                ..Metadata::default()
+            }),
+        };
+        let exec_msg = ExecuteMsg::BaseMsg(cw721_base::ExecuteMsg::Mint(mint_msg.clone()));
+        context.execute(mock_info(CREATOR, &[]), exec_msg).unwrap();
+
+        let msg = Cw721SellableExecuteMsg::RedeemTicket {
+            address: String::from(OWNER),
+            ticket_id: String::from(token_id)
+        };
+        context.execute(mock_info(CREATOR, &[]), msg).unwrap();
+
+        let contract = Cw721SellableContract::default();
+
+        let res = contract.nft_info(context.deps.as_ref(), token_id.to_string()).unwrap();
+        match res {
+            NftInfoResponse::<Extension> { token_uri, extension } => {
+                let metadata = extension.unwrap();
+                if metadata.redeemed.unwrap() {
+                    assert!(true);
+                } else {
+                    assert!(false);
+                }
+            },
+            _ => assert!(false)
+        }
     }
 }

--- a/contracts/cw721-sellable/src/lib.rs
+++ b/contracts/cw721-sellable/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Metadata {
     pub royalty_payment_address: Option<String>,
     pub list_price: Option<Uint64>,
     pub locked: Option<bool>,
-    pub redeemed: Option<bool>
+    pub redeemed: Option<bool>,
 }
 
 pub type Extension = Option<Metadata>;
@@ -102,19 +102,19 @@ mod entry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::test_utils::{Context, ContractInfo};
-    use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg};
     use crate::entry::{execute, instantiate, query};
     use crate::error::ContractError;
-    
+    use crate::test_utils::test_utils::{Context, ContractInfo};
+    use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg};
+
     use crate::msg::Cw721SellableQueryMsg;
     use crate::query::ListedTokensResponse;
-    use cosmwasm_std::testing::{mock_info};
-    use schemars::Map;
+    use cosmwasm_std::testing::mock_info;
+    use cw2981_royalties::msg::Cw2981QueryMsg;
     use cw2981_royalties::InstantiateMsg;
-    use cw2981_royalties::msg::{Cw2981QueryMsg};
-    use cw721::{NftInfoResponse};
     use cw721::Cw721Query;
+    use cw721::NftInfoResponse;
+    use schemars::Map;
 
     const CREATOR: &str = "creator";
     const OWNER: &str = "owner";
@@ -363,15 +363,15 @@ mod tests {
             ContractInfo {
                 name: "Ticketing".to_string(),
                 symbol: "TICK".to_string(),
-            }, 
+            },
             CREATOR,
-            Some(&[])
+            Some(&[]),
         );
 
         // Make sure only the owner of the contract can call method
         let msg = Cw721SellableExecuteMsg::RedeemTicket {
             address: String::from(OWNER),
-            ticket_id: String::from("OWNER_TICKET")
+            ticket_id: String::from("OWNER_TICKET"),
         };
         let exec_res = context.execute(mock_info(OWNER, &[]), msg).err();
         match exec_res {
@@ -382,12 +382,12 @@ mod tests {
         // Throw Error if ticket does exists in the contract
         let msg = Cw721SellableExecuteMsg::RedeemTicket {
             address: String::from(OWNER),
-            ticket_id: String::from("OWNER_TICKET")
+            ticket_id: String::from("OWNER_TICKET"),
         };
         let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
         match exec_res {
             None => assert!(false),
-            _ => assert!(true)
+            _ => assert!(true),
         };
 
         // Make sure the owner param is the same as ticket owner in contract
@@ -407,12 +407,12 @@ mod tests {
 
         let msg = Cw721SellableExecuteMsg::RedeemTicket {
             address: String::from(BUYER), // Ticket owner is BUYER here
-            ticket_id: String::from("Burnt_Event#1")
+            ticket_id: String::from("Burnt_Event#1"),
         };
         let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
         match exec_res {
             Some(ContractError::Unauthorized) => assert!(true),
-            _ => assert!(false)
+            _ => assert!(false),
         };
 
         // Make sure the ticket is not locked  or redeemed
@@ -433,12 +433,12 @@ mod tests {
         // Try to redeem locked ticket
         let msg = Cw721SellableExecuteMsg::RedeemTicket {
             address: String::from(OWNER),
-            ticket_id: String::from("Burnt_Locked#1")
+            ticket_id: String::from("Burnt_Locked#1"),
         };
         let exec_res = context.execute(mock_info(CREATOR, &[]), msg).err();
         match exec_res {
             Some(ContractError::Locked) => assert!(true),
-            _ => assert!(false)
+            _ => assert!(false),
         };
 
         // Make sure the ticket metadata is updated
@@ -460,23 +460,28 @@ mod tests {
 
         let msg = Cw721SellableExecuteMsg::RedeemTicket {
             address: String::from(OWNER),
-            ticket_id: String::from(token_id)
+            ticket_id: String::from(token_id),
         };
         context.execute(mock_info(CREATOR, &[]), msg).unwrap();
 
         let contract = Cw721SellableContract::default();
 
-        let res = contract.nft_info(context.deps.as_ref(), token_id.to_string()).unwrap();
+        let res = contract
+            .nft_info(context.deps.as_ref(), token_id.to_string())
+            .unwrap();
         match res {
-            NftInfoResponse::<Extension> { token_uri, extension } => {
+            NftInfoResponse::<Extension> {
+                token_uri,
+                extension,
+            } => {
                 let metadata = extension.unwrap();
                 if metadata.redeemed.unwrap() {
                     assert!(true);
                 } else {
                     assert!(false);
                 }
-            },
-            _ => assert!(false)
+            }
+            _ => assert!(false),
         }
     }
 }

--- a/contracts/cw721-sellable/src/lib.rs
+++ b/contracts/cw721-sellable/src/lib.rs
@@ -91,7 +91,7 @@ mod entry {
         match msg {
             List { listings } => try_list(deps, env, info, listings),
             Buy { limit } => try_buy(deps, info, limit),
-            RedeemTicket { address, ticket_id } => try_redeem(deps, env, info, address, &ticket_id),
+            RedeemTicket { address, ticket_id } => try_redeem(deps, info, address, &ticket_id),
             BaseMsg(base_msg) => Cw721SellableContract::default()
                 .execute(deps, env, info, base_msg)
                 .map_err(|x| x.into()),
@@ -109,7 +109,7 @@ mod tests {
     
     use crate::msg::Cw721SellableQueryMsg;
     use crate::query::ListedTokensResponse;
-    use cosmwasm_std::testing::{mock_info, mock_dependencies, mock_env};
+    use cosmwasm_std::testing::{mock_info};
     use schemars::Map;
     use cw2981_royalties::InstantiateMsg;
     use cw2981_royalties::msg::{Cw2981QueryMsg};

--- a/contracts/cw721-sellable/src/msg.rs
+++ b/contracts/cw721-sellable/src/msg.rs
@@ -21,6 +21,12 @@ pub enum Cw721SellableExecuteMsg<T> {
     Buy {
         limit: Uint64,
     },
+
+    /// Mark ticket has redeemed
+    RedeemTicket {
+        address: String,
+        ticket_id: String
+    }
 }
 
 type BaseExecuteMsg = cw721_base::ExecuteMsg<Extension>;

--- a/contracts/cw721-sellable/src/msg.rs
+++ b/contracts/cw721-sellable/src/msg.rs
@@ -25,8 +25,8 @@ pub enum Cw721SellableExecuteMsg<T> {
     /// Mark ticket has redeemed
     RedeemTicket {
         address: String,
-        ticket_id: String
-    }
+        ticket_id: String,
+    },
 }
 
 type BaseExecuteMsg = cw721_base::ExecuteMsg<Extension>;

--- a/contracts/cw721-sellable/src/test_utils.rs
+++ b/contracts/cw721-sellable/src/test_utils.rs
@@ -4,12 +4,12 @@ pub mod test_utils {
     use crate::msg::Cw721SellableQueryMsg;
     use crate::{entry, Cw721SellableContract, ExecuteMsg};
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_dependencies_with_balances, mock_env, mock_info, MockApi, MockQuerier,
-        MockStorage,
+        mock_dependencies, mock_dependencies_with_balances, mock_env, mock_info, MockApi,
+        MockQuerier, MockStorage,
     };
     use cosmwasm_std::{from_binary, Coin, MessageInfo, OwnedDeps, Response, StdResult};
     use serde::de::DeserializeOwned;
-    
+
     pub fn hello() -> String {
         return "hello".to_string();
     }
@@ -17,12 +17,12 @@ pub mod test_utils {
         pub deps: OwnedDeps<MockStorage, MockApi, MockQuerier>,
         pub contract: Cw721SellableContract<'a>,
     }
-    
+
     pub struct ContractInfo {
         pub name: String,
         pub symbol: String,
     }
-    
+
     impl Context<'_> {
         pub fn new<'a>(
             contract_info: ContractInfo,
@@ -34,7 +34,7 @@ pub mod test_utils {
             } else {
                 mock_dependencies()
             };
-    
+
             let contract = Cw721SellableContract::default();
             let creator_info = mock_info(creator, &[]);
             let init_msg = cw721_base::InstantiateMsg {
@@ -45,10 +45,10 @@ pub mod test_utils {
             contract
                 .instantiate(deps.as_mut(), mock_env(), creator_info.clone(), init_msg)
                 .unwrap();
-    
+
             Context { deps, contract }
         }
-    
+
         pub fn execute(
             &mut self,
             creator_info: MessageInfo,
@@ -56,13 +56,13 @@ pub mod test_utils {
         ) -> Result<Response, ContractError> {
             entry::execute(self.deps.as_mut(), mock_env(), creator_info, msg)
         }
-    
+
         pub fn query<T: DeserializeOwned>(&self, msg: Cw721SellableQueryMsg) -> StdResult<T> {
             let binary_res = entry::query(self.deps.as_ref(), mock_env(), msg);
             binary_res.and_then(|bin| from_binary(&bin))
         }
     }
-    
+
     impl Default for Context<'_> {
         fn default() -> Self {
             Context::new(

--- a/contracts/cw721-sellable/src/test_utils.rs
+++ b/contracts/cw721-sellable/src/test_utils.rs
@@ -1,72 +1,78 @@
-use crate::error::ContractError;
-use crate::msg::Cw721SellableQueryMsg;
-use crate::{entry, Cw721SellableContract, ExecuteMsg};
-use cosmwasm_std::testing::{
-    mock_dependencies, mock_dependencies_with_balances, mock_env, mock_info, MockApi, MockQuerier,
-    MockStorage,
-};
-use cosmwasm_std::{from_binary, Coin, MessageInfo, OwnedDeps, Response, StdResult};
-use serde::de::DeserializeOwned;
-
-pub struct Context<'a> {
-    pub deps: OwnedDeps<MockStorage, MockApi, MockQuerier>,
-    pub contract: Cw721SellableContract<'a>,
-}
-
-pub struct ContractInfo {
-    pub name: String,
-    pub symbol: String,
-}
-
-impl Context<'_> {
-    pub fn new<'a>(
-        contract_info: ContractInfo,
-        creator: &'a str,
-        balances: Option<&[(&str, &[Coin])]>,
-    ) -> Context<'a> {
-        let mut deps = if let Some(balances) = balances {
-            mock_dependencies_with_balances(balances)
-        } else {
-            mock_dependencies()
-        };
-
-        let contract = Cw721SellableContract::default();
-        let creator_info = mock_info(creator, &[]);
-        let init_msg = cw721_base::InstantiateMsg {
-            name: contract_info.name,
-            symbol: contract_info.symbol,
-            minter: creator.to_string(),
-        };
-        contract
-            .instantiate(deps.as_mut(), mock_env(), creator_info.clone(), init_msg)
-            .unwrap();
-
-        Context { deps, contract }
+#[cfg(test)]
+pub mod test_utils {
+    use crate::error::ContractError;
+    use crate::msg::Cw721SellableQueryMsg;
+    use crate::{entry, Cw721SellableContract, ExecuteMsg};
+    use cosmwasm_std::testing::{
+        mock_dependencies, mock_dependencies_with_balances, mock_env, mock_info, MockApi, MockQuerier,
+        MockStorage,
+    };
+    use cosmwasm_std::{from_binary, Coin, MessageInfo, OwnedDeps, Response, StdResult};
+    use serde::de::DeserializeOwned;
+    
+    pub fn hello() -> String {
+        return "hello".to_string();
     }
-
-    pub fn execute(
-        &mut self,
-        creator_info: MessageInfo,
-        msg: ExecuteMsg,
-    ) -> Result<Response, ContractError> {
-        entry::execute(self.deps.as_mut(), mock_env(), creator_info, msg)
+    pub struct Context<'a> {
+        pub deps: OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        pub contract: Cw721SellableContract<'a>,
     }
-
-    pub fn query<T: DeserializeOwned>(&self, msg: Cw721SellableQueryMsg) -> StdResult<T> {
-        let binary_res = entry::query(self.deps.as_ref(), mock_env(), msg);
-        binary_res.and_then(|bin| from_binary(&bin))
+    
+    pub struct ContractInfo {
+        pub name: String,
+        pub symbol: String,
     }
-}
-
-impl Default for Context<'_> {
-    fn default() -> Self {
-        Context::new(
-            ContractInfo {
-                name: "SpaceShips".into(),
-                symbol: "SPACE".into(),
-            },
-            "creator",
-            None,
-        )
+    
+    impl Context<'_> {
+        pub fn new<'a>(
+            contract_info: ContractInfo,
+            creator: &'a str,
+            balances: Option<&[(&str, &[Coin])]>,
+        ) -> Context<'a> {
+            let mut deps = if let Some(balances) = balances {
+                mock_dependencies_with_balances(balances)
+            } else {
+                mock_dependencies()
+            };
+    
+            let contract = Cw721SellableContract::default();
+            let creator_info = mock_info(creator, &[]);
+            let init_msg = cw721_base::InstantiateMsg {
+                name: contract_info.name,
+                symbol: contract_info.symbol,
+                minter: creator.to_string(),
+            };
+            contract
+                .instantiate(deps.as_mut(), mock_env(), creator_info.clone(), init_msg)
+                .unwrap();
+    
+            Context { deps, contract }
+        }
+    
+        pub fn execute(
+            &mut self,
+            creator_info: MessageInfo,
+            msg: ExecuteMsg,
+        ) -> Result<Response, ContractError> {
+            entry::execute(self.deps.as_mut(), mock_env(), creator_info, msg)
+        }
+    
+        pub fn query<T: DeserializeOwned>(&self, msg: Cw721SellableQueryMsg) -> StdResult<T> {
+            let binary_res = entry::query(self.deps.as_ref(), mock_env(), msg);
+            binary_res.and_then(|bin| from_binary(&bin))
+        }
+    }
+    
+    impl Default for Context<'_> {
+        fn default() -> Self {
+            Context::new(
+                ContractInfo {
+                    name: "SpaceShips".into(),
+                    symbol: "SPACE".into(),
+                },
+                "creator",
+                None,
+            )
+        }
     }
 }


### PR DESCRIPTION
# Feature

This PR would add into the sellable contract a redemption utility for tickets. The details of the redemption flow can be found [here](https://docs.google.com/document/d/1I9Cul-JLOLuY2kKBwECG1Y0xZKqILuqwoAhMx4OW7c8/edit) and task description [here](https://burnt.atlassian.net/jira/software/c/projects/DAPP/boards/3?modal=detail&selectedIssue=DAPP-233).